### PR TITLE
drivers: usb: gadget: Fix usb tethering by enforcing ncm

### DIFF
--- a/drivers/usb/gadget/function/u_ether.c
+++ b/drivers/usb/gadget/function/u_ether.c
@@ -708,7 +708,7 @@ static netdev_tx_t eth_start_xmit(struct sk_buff *skb,
 		cdc_filter = dev->port_usb->cdc_filter;
 		eth_multi_pkt_xfer = dev->port_usb->multi_pkt_xfer;
 		eth_supports_multi_frame = dev->port_usb->supports_multi_frame;
-		eth_is_fixed = dev->port_usb->is_fixed;
+		eth_is_fixed = 1;
 	} else {
 		in = NULL;
 		cdc_filter = 0;


### PR DESCRIPTION
For a thus far unknown reason, we hit an npe when using rndis without multi packet transfer.

More specifically, the npe is cause by the following memcpy:

/* copy skb data */
memcpy(req->buf, skb->data,
	skb->len);

I will revisit it later to see if it can be fixed properly. But tests show that sharing WiFi and mobile data now works both on Windows and Linux, so let's fix it for now.