### PR TITLE
Revert "sec-ts: force enable fingerprint"

### DIFF
--- a/drivers/input/touchscreen/sec_ts/y771/sec_ts.c
+++ b/drivers/input/touchscreen/sec_ts/y771/sec_ts.c
@@ -2001,9 +2001,11 @@ int sec_ts_set_custom_library(struct sec_ts_data *ts)
 	if (!ts->use_sponge)
 		return 0;
 
-	/* enable FOD when supported by device */
-	if (ts->plat_data->support_fod)
+#ifdef CONFIG_SEC_FACTORY
+	/* enable FOD when LCD on state */
+	if (ts->plat_data->support_fod && ts->input_closed == false)
 		force_fod_enable = SEC_TS_MODE_SPONGE_PRESS;
+#endif
 
 	input_err(true, &ts->client->dev, "%s: Sponge (0x%02x)%s\n",
 			__func__, ts->lowpower_mode,


### PR DESCRIPTION
This reverts commit c92e0b0248c90fe7eb8ecbe0092c3cc06c15f61e.

This is no longer needed when https://review.lineageos.org/c/LineageOS/android_hardware_samsung/+/279938 gets merged.